### PR TITLE
install for local-fs.target instead of multi-user.target

### DIFF
--- a/sw/pistackmond.service
+++ b/sw/pistackmond.service
@@ -7,4 +7,4 @@ User=root
 ExecStart=/usr/local/sbin/pistackmond
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=local-fs.target


### PR DESCRIPTION
A first (minor) change. This starts pistackmon directly after the local filesystems are ready.